### PR TITLE
Update main.hbs

### DIFF
--- a/dist/views/main.hbs
+++ b/dist/views/main.hbs
@@ -117,11 +117,11 @@
                 getAdjustedBaseUrl() {
                     const origin = window.location.origin;
                     const pathname = window.location.pathname;
-                    if (pathname.endsWith('.html')) {
-                        const directoryPath = pathname.substring(0, pathname.lastIndexOf('/') + 1);
+                    if (pathname.endsWith('.html') || pathname.endsWith('/')) {
+                        const directoryPath = pathname.substring(0, pathname.lastIndexOf('/'));
                         return `${origin}${directoryPath}`;
                     }
-                    return origin;
+                    return `${origin}${pathname}`;
                 },
 
                 /**


### PR DESCRIPTION
Keep the entire origin and pathname when opening the new trace window and when using data-trace content. Avoid having double / when the pathname ends with .html