### PR TITLE
🎨ENC: Enable History for Sharding Merge Report

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -46,11 +46,12 @@ program
     "ortoni-report"
   )
   .option("-f, --file <filename>", "Output report file", "ortoni-report.html")
+  .option("-s, --save-history", "Save report history", false)
   .action(async (options) => {
     await mergeAllData({
       dir: options.dir,
       file: options.file,
-      saveHistory: false,
+      saveHistory: options.saveHistory,
     });
   });
 


### PR DESCRIPTION
cli.js
- Add "-s, --save-history" option for user to enable history having default value 'false'.

Have tested locally:
<img width="963" height="228" alt="image" src="https://github.com/user-attachments/assets/7b891c94-a645-4efa-a6ce-35ee4c614697" />

Checkout the report screenshot:
<img width="1468" height="702" alt="image" src="https://github.com/user-attachments/assets/dcb58648-2465-49fc-a545-8ff1c02fe668" />
 &&
<img width="1903" height="936" alt="image" src="https://github.com/user-attachments/assets/69c69c44-09c8-4318-9811-461be6233f8b" />

Pls do share if you see any point missing. Looking forward to this feature.